### PR TITLE
Bug fix on Matrix2D.js decompose function

### DIFF
--- a/src/easeljs/geom/Matrix2D.js
+++ b/src/easeljs/geom/Matrix2D.js
@@ -504,6 +504,7 @@ this.createjs = this.createjs||{};
 		} else {
 			target.skewX = skewX/Matrix2D.DEG_TO_RAD;
 			target.skewY = skewY/Matrix2D.DEG_TO_RAD;
+			target.rotation = 0;
 		}
 		return target;
 	};


### PR DESCRIPTION
Reset rotation value to zero if skewX and skewY is used, and rotation value is non-zero in the target.
